### PR TITLE
Added Xtext and XTend to the p2 director

### DIFF
--- a/Jnario.setup
+++ b/Jnario.setup
@@ -42,6 +42,14 @@
       storageURI="scope://Workspace"/>
   <setupTask
       xsi:type="setup.p2:P2Task">
+    <requirement
+        name="org.eclipse.xtend.sdk.feature.group"/>
+    <requirement
+        name="org.eclipse.xtext.sdk.feature.group"/>
+    <repository
+        url="http://download.eclipse.org/releases/neon"/>
+    <repository
+        url="http://download.eclipse.org/modeling/tmf/xtext/updates/composite/milestones/"/>
     <description>Install the tools needed in the IDE to work with the source code for ${scope.project.label}</description>
   </setupTask>
   <setupTask


### PR DESCRIPTION
The setup can now be deployed on non dsl based oomph installations (The
RCP installation for example) It will pull in xtext and xtend into the
installation