### PR TITLE
fix #24 TokenTypePartitioning for richstrings

### DIFF
--- a/plugins/org.jnario.feature.ui/src/org/jnario/feature/ui/editor/FeatureDoubleClickStrategyProvider.java
+++ b/plugins/org.jnario.feature.ui/src/org/jnario/feature/ui/editor/FeatureDoubleClickStrategyProvider.java
@@ -9,10 +9,10 @@ package org.jnario.feature.ui.editor;
 
 import org.eclipse.jface.text.ITextDoubleClickStrategy;
 import org.eclipse.jface.text.source.ISourceViewer;
-import org.eclipse.xtext.ui.editor.doubleClicking.DoubleClickStrategyProvider;
 import org.eclipse.xtext.ui.editor.doubleClicking.FixedCharCountPartitionDoubleClickSelector;
+import org.jnario.xbase.richstring.ui.editor.XbaseWithRichstringDoubleClickStrategyProvider;
 
-public class FeatureDoubleClickStrategyProvider extends DoubleClickStrategyProvider {
+public class FeatureDoubleClickStrategyProvider extends XbaseWithRichstringDoubleClickStrategyProvider {
 
 	
 	public ITextDoubleClickStrategy getStrategy(ISourceViewer sourceViewer, String contentType, String documentPartitioning) {

--- a/plugins/org.jnario.feature.ui/src/org/jnario/feature/ui/editor/FeatureTokenTypeToPartitionTypeMapper.java
+++ b/plugins/org.jnario.feature.ui/src/org/jnario/feature/ui/editor/FeatureTokenTypeToPartitionTypeMapper.java
@@ -10,6 +10,7 @@ package org.jnario.feature.ui.editor;
 import java.util.HashSet;
 
 import org.eclipse.xtext.ui.editor.model.TerminalsTokenTypeToPartitionMapper;
+import org.jnario.xbase.richstring.ui.autoedit.TokenTypeToPartitionMapper;
 
 import com.google.common.collect.Sets;
 import com.google.inject.Singleton;
@@ -18,7 +19,7 @@ import com.google.inject.Singleton;
  * @author Birgit Engelmann - Initial contribution and API
  */
 @Singleton
-public class FeatureTokenTypeToPartitionTypeMapper extends TerminalsTokenTypeToPartitionMapper{
+public class FeatureTokenTypeToPartitionTypeMapper extends TokenTypeToPartitionMapper{
 
 	public static final String NONE_CODE_PARTITION = "__no_code";
 	

--- a/plugins/org.jnario.spec.ui/src/org/jnario/spec/ui/SpecUiModule.java
+++ b/plugins/org.jnario.spec.ui/src/org/jnario/spec/ui/SpecUiModule.java
@@ -32,10 +32,12 @@ import org.eclipse.xtext.ui.editor.contentassist.IContextInformationProvider;
 import org.eclipse.xtext.ui.editor.contentassist.IProposalConflictHelper;
 import org.eclipse.xtext.ui.editor.contentassist.antlr.AntlrProposalConflictHelper;
 import org.eclipse.xtext.ui.editor.copyqualifiedname.CopyQualifiedNameService;
+import org.eclipse.xtext.ui.editor.doubleClicking.DoubleClickStrategyProvider;
 import org.eclipse.xtext.ui.editor.findrefs.IReferenceFinder;
 import org.eclipse.xtext.ui.editor.folding.IFoldingRegionProvider;
 import org.eclipse.xtext.ui.editor.hover.IEObjectHoverProvider;
 import org.eclipse.xtext.ui.editor.model.IResourceForEditorInputFactory;
+import org.eclipse.xtext.ui.editor.model.ITokenTypeToPartitionTypeMapper;
 import org.eclipse.xtext.ui.editor.syntaxcoloring.AbstractAntlrTokenToAttributeIdMapper;
 import org.eclipse.xtext.ui.editor.syntaxcoloring.IHighlightingConfiguration;
 import org.eclipse.xtext.ui.editor.syntaxcoloring.ISemanticHighlightingCalculator;
@@ -63,7 +65,9 @@ import org.jnario.ui.editor.XtendCopyQualifiedNameService;
 import org.jnario.ui.highlighting.JnarioHighlightingConfiguration;
 import org.jnario.ui.highlighting.RichStringAwareTokenScanner;
 import org.jnario.ui.highlighting.TokenToAttributeIdMapper;
+import org.jnario.xbase.richstring.ui.autoedit.TokenTypeToPartitionMapper;
 import org.jnario.xbase.richstring.ui.autoedit.XbaseWithRichstringAutoEditStrategyProvider;
+import org.jnario.xbase.richstring.ui.editor.XbaseWithRichstringDoubleClickStrategyProvider;
 
 import com.google.inject.Binder;
 import com.google.inject.name.Names;
@@ -151,18 +155,18 @@ public class SpecUiModule extends org.jnario.spec.ui.AbstractSpecUiModule {
 		return SpecHighlightingCalculator.class;
 	}
 
-//	public Class<? extends ITokenTypeToPartitionTypeMapper> bindITokenTypeToPartitionTypeMapper() {
-//		return TokenTypeToPartitionMapper.class;
-//	}
-//
+	public Class<? extends ITokenTypeToPartitionTypeMapper> bindITokenTypeToPartitionTypeMapper() {
+		return TokenTypeToPartitionMapper.class;
+	}
+
 	@Override
 	public Class<? extends AbstractEditStrategyProvider> bindAbstractEditStrategyProvider() {
 		return XbaseWithRichstringAutoEditStrategyProvider.class;
 	}
-//
-//	public Class<? extends DoubleClickStrategyProvider> bindDoubleClickStrategyProvider() {
-//		return XtendDoubleClickStrategyProvider.class;
-//	}
+
+	public Class<? extends DoubleClickStrategyProvider> bindDoubleClickStrategyProvider() {
+		return XbaseWithRichstringDoubleClickStrategyProvider.class;
+	}
 
 //	@Override
 //	public Class<? extends IComparator> bindOutlineFilterAndSorter$IComparator() {

--- a/plugins/org.jnario.xbase.richstring.ui/META-INF/MANIFEST.MF
+++ b/plugins/org.jnario.xbase.richstring.ui/META-INF/MANIFEST.MF
@@ -17,10 +17,12 @@ Require-Bundle: org.jnario.xbase.richstring,
  org.eclipse.xtext.common.types.ui,
  org.eclipse.jdt.debug.ui,
  org.antlr.runtime
-Import-Package: org.apache.log4j
+Import-Package: com.ibm.icu.text;version="56.1.0",
+ org.apache.log4j
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Export-Package: org.jnario.xbase.richstring.ui.autoedit,
  org.jnario.xbase.richstring.ui.contentassist,
+ org.jnario.xbase.richstring.ui.editor,
  org.jnario.xbase.richstring.ui.highlighting,
  org.jnario.xbase.richstring.ui.quickfix
 Bundle-Activator: org.jnario.xbase.richstring.ui.internal.XbaseWithRichstringActivator

--- a/plugins/org.jnario.xbase.richstring.ui/src/org/jnario/xbase/richstring/ui/XbaseWithRichstringUiModule.java
+++ b/plugins/org.jnario.xbase.richstring.ui/src/org/jnario/xbase/richstring/ui/XbaseWithRichstringUiModule.java
@@ -19,4 +19,6 @@ public class XbaseWithRichstringUiModule extends org.jnario.xbase.richstring.ui.
 	public Class<? extends AbstractEditStrategyProvider> bindAbstractEditStrategyProvider() {
 		return XbaseWithRichstringAutoEditStrategyProvider.class;
 	}
+	
+	
 }

--- a/plugins/org.jnario.xbase.richstring.ui/src/org/jnario/xbase/richstring/ui/editor/XbaseWithRichstringDoubleClickStrategyProvider.java
+++ b/plugins/org.jnario.xbase.richstring.ui/src/org/jnario/xbase/richstring/ui/editor/XbaseWithRichstringDoubleClickStrategyProvider.java
@@ -1,0 +1,134 @@
+package org.jnario.xbase.richstring.ui.editor;
+
+
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.jface.text.ITextDoubleClickStrategy;
+import org.eclipse.jface.text.ITypedRegion;
+import org.eclipse.jface.text.Region;
+import org.eclipse.jface.text.source.ISourceViewer;
+import org.eclipse.xtext.ui.editor.doubleClicking.AbstractPartitionDoubleClickSelector;
+import org.eclipse.xtext.ui.editor.doubleClicking.DoubleClickStrategyProvider;
+import org.eclipse.xtext.ui.editor.model.CommonBreakIterator;
+import org.jnario.xbase.richstring.ui.autoedit.TokenTypeToPartitionMapper;
+
+/**
+ * Double click strategy that is aware of rich string partitions.
+ * 
+ * @author Sebastian Zarnekow - Initial contribution and API
+ */
+public class XbaseWithRichstringDoubleClickStrategyProvider extends DoubleClickStrategyProvider {
+
+	@Override
+	public ITextDoubleClickStrategy getStrategy(ISourceViewer sourceViewer, String contentType,
+			String documentPartitioning) {
+		if (TokenTypeToPartitionMapper.RICH_STRING_LITERAL_PARTITION.equals(contentType)) {
+			return new AbstractPartitionDoubleClickSelector(documentPartitioning) {
+				
+				@Override
+				protected IRegion getSelectedRegion(IDocument document, ITypedRegion completePartition)
+						throws BadLocationException {
+					String content = document.get(completePartition.getOffset(), completePartition.getLength());
+					int trimLeft = 1; // assume « as start character
+					if (content.startsWith("'''")) {
+						trimLeft = 3;
+					}
+					int trimRight = 0;
+					if (content.endsWith("'''")) {
+						trimRight = 3;
+					} else if (content.endsWith("''")) {
+						trimRight = 2;
+					} else if (content.endsWith("'") || content.endsWith("\u00AB")) {
+						trimRight = 1;
+					}
+					return new Region(completePartition.getOffset() + trimLeft, completePartition.getLength() - trimLeft - trimRight);
+				}
+				
+			};
+		}
+		if (TokenTypeToPartitionMapper.JAVA_DOC_PARTITION.equals(contentType)) {
+			return new AbstractPartitionDoubleClickSelector(documentPartitioning) {
+
+				/**
+				 * Allows to select the complete <code>@param</code> instead of just the literal <code>param</code>.
+				 * Copied from org.eclipse.jdt.internal.ui.text.java.JavadocDoubleClickStrategy.
+				 */
+				@Override
+				protected IRegion findExtendedDoubleClickSelection(IDocument document, int position) {
+					try {
+						IRegion match = super.findExtendedDoubleClickSelection(document, position);
+						if (match != null)
+							return match;
+
+						IRegion word = findWord(document, position);
+
+						IRegion line = document.getLineInformationOfOffset(position);
+						if (position == line.getOffset() + line.getLength())
+							return null;
+
+						int start = word.getOffset();
+						int end = start + word.getLength();
+
+						if (start > 0
+								&& document.getChar(start - 1) == '@'
+								&& Character.isJavaIdentifierPart(document.getChar(start))
+								&& (start == 1 || Character.isWhitespace(document.getChar(start - 2)) || document.getChar(start - 2) == '{')) {
+							// double click after @ident
+							start--;
+						} else if (end == position 
+								&& end == start + 1 
+								&& end < line.getOffset() + line.getLength()
+								&& document.getChar(end) == '@') {
+							// double click before " @ident"
+							return findExtendedDoubleClickSelection(document, position + 1);
+						}
+
+						if (start == end)
+							return null;
+						return new Region(start, end - start);
+
+					} catch (BadLocationException x) {
+						return null;
+					}
+				}
+
+				@Override
+				protected CommonBreakIterator createBreakIterator() {
+					return new CommonBreakIterator(false) {
+						class Braces extends Other {
+							@Override
+							protected boolean isValid(char ch) {
+								return ch == '{' || ch == '}';
+							}
+						}
+
+						class Parentheses extends Other {
+							@Override
+							protected boolean isValid(char ch) {
+								return ch == '(' || ch == ')';
+							}
+						}
+
+						Braces braces = new Braces();
+						Parentheses parentheses = new Parentheses();
+
+						@Override
+						protected Run getRun(char ch) {
+							if (braces.isValid(ch)) {
+								return braces;
+							}
+							if (parentheses.isValid(ch)) {
+								return parentheses;
+							}
+							return super.getRun(ch);
+						}
+					};
+				}
+			};
+
+		}
+		return super.getStrategy(sourceViewer, contentType, documentPartitioning);
+	}
+
+}


### PR DESCRIPTION
When doubleclicking a word inside a richstring the whole richstring was
selected by the editor. After binding the correct
ITokenTypeToPartioningTypeMapper and an appropriate DoubleClickStrategy
Richstring-Tokens are handled by finding selecting the word under the
courser, instead of selecting the whole token.

fixes issue #24 